### PR TITLE
feat: add verification for failed login attempts and refactor test setup

### DIFF
--- a/resources/keywords/auth.resource
+++ b/resources/keywords/auth.resource
@@ -52,3 +52,7 @@ Login User
 
 Navigate To Login Page
     common.Find And Click Element    xpath=//a[@href='/login']
+
+Verify Login Failed
+    SeleniumLibrary.Wait Until Element Is Visible    xpath=//p[contains(text(),'Your email or password is incorrect!')]    timeout=10s
+    SeleniumLibrary.Element Should Be Visible    xpath=//p[contains(text(),'Your email or password is incorrect!')]

--- a/tests/auth.robot
+++ b/tests/auth.robot
@@ -3,12 +3,12 @@ Resource    ../resources/keywords/common.resource
 Resource    ../resources/keywords/auth.resource
 Resource    ../resources/keywords/api.resource
 
+Test Setup    Run Keywords    common.Open Browser To URL    
+...                    AND    auth.Navigate To Login Page
 
 *** Test Cases ***
 Register User
     [Documentation]    Test user registration functionality
-    common.Open Browser To URL
-    auth.Navigate To Login Page
     ${user}    common.Generate Profile
     auth.Register New User    ${user}
     auth.Verify Account Created
@@ -17,10 +17,14 @@ Register User
 
 Login User with correct email and password
     [Documentation]    Test user login functionality with valid credentials
-    common.Open Browser To URL
-    auth.Navigate To Login Page
     ${user}    common.Generate Profile
     api.Create User    ${user}
     auth.Login User    ${user}
     auth.Verify Logged In As Username    ${user}
     auth.Delete Account
+
+Login User with incorrect email and password
+    [Documentation]    Test user login functionality with invalid credentials
+    ${invalid_user}    Create Dictionary    mail=invalid_email@test.com    password=wrongpassword
+    auth.Login User    ${invalid_user}
+    auth.Verify Login Failed


### PR DESCRIPTION
This pull request improves the authentication test suite by adding negative login tests, refactoring setup steps to reduce duplication, and enhancing keyword reusability. The most important changes are grouped below:

**Test Coverage Improvements:**

* Added a new test case, `Login User with incorrect email and password`, to verify that login fails when invalid credentials are used. This strengthens the test suite by ensuring failed login scenarios are properly handled.
* Introduced the `Verify Login Failed` keyword in `auth.resource` to assert that the appropriate error message is shown for failed logins.

**Test Suite Refactoring:**

* Refactored the test setup in `auth.robot` to use a global `Test Setup` that opens the browser and navigates to the login page, removing duplicate setup steps from individual test cases.